### PR TITLE
Quality Report display

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "write-file-webpack-plugin": "^3.1.8"
   },
   "dependencies": {
-    "axios": "^0.14.0"
+    "axios": "^0.14.0",
+    "victory": "^0.11.0"
   }
 }

--- a/src/components/QualityReport.js
+++ b/src/components/QualityReport.js
@@ -1,4 +1,6 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
+
+import { VictoryPie } from 'victory';
 
 import qualityReportProps from '../prop-types/quality_report';
 import measureProps from '../prop-types/measure';
@@ -6,16 +8,116 @@ import measureProps from '../prop-types/measure';
 export default class QualityReport extends Component {
   render() {
     return (
-      <div>
-        <p>{this.submeasureDisplay()}</p>
-        {(() => {
-          if (this.props.qualityReport.status.state === "completed") {
-            return (<p>Result: {this.props.qualityReport.result.numerator} / {this.props.qualityReport.result.denominator}</p>);
-          } else {
-            return (<p>Loading...</p>);
-          }
-        })()}
+      <div className="row">
+        <div className="col-md-3">{this.props.index === 0 ? this.props.measure.description : ""}</div>
+        <div className="col-md-1">{this.submeasureDisplay()}</div>
+        <div className="col-md-1">{this.measureIcon()}</div>
+        <div className="col-md-4">{this.resultsTable()}</div>
+        <div className="col-md-3">{this.resultsDoughnut()}</div>
       </div>
+    );
+  }
+
+  measureIcon() {
+    if (this.props.index === 0) {
+      if (this.props.measure.episodeOfCare && !this.props.measure.continuousVariable) {
+        return <i className="fa fa-stethoscope" aria-hidden="true"></i>;
+      }
+      if (this.props.measure.continuousVariable) {
+        return <i className="fa fa-tachometer" aria-hidden="true"></i>;
+      }
+      return <i className="fa fa-user" aria-hidden="true"></i>;
+    } else {
+      return "";
+    }
+  }
+
+  resultsDoughnut() {
+    if (this.props.qualityReport.status.state === "completed" &&
+        this.props.qualityReport.result.numerator > 0 &&
+        this.props.qualityReport.result.denominator > 0 &&
+        this.props.measure.continuousVariable === false) {
+
+      let outliers = this.props.qualityReport.result.initialPatientPopulation - this.props.qualityReport.result.numerator;
+                    //- this.props.qualityReport.result.exclusion - this.props.qualityReport.result.exception;
+      let data = [{x: "Numerator", y: this.props.qualityReport.result.numerator},
+                  {x: "Outliers", y: outliers }];
+      let colorScale = ["#3B858C", "#EFEFEF"];
+      if (this.props.qualityReport.result.exclusion > 0) {
+        data.push({x: "Exclusions", y: this.props.qualityReport.result.exclusion});
+        colorScale.push("#C1C1C1");
+      }
+      if (this.props.qualityReport.result.exception > 0) {
+        data.push({x: "Exceptions", y: this.props.qualityReport.result.exception});
+        colorScale.push("#C1C1C1");
+      }
+      return <VictoryPie data={data} colorScale={colorScale} innerRadius={110}
+      style={{
+        labels: {
+          fill: "black",
+          fontSize: 20,
+          fontWeight: "bold",
+          padding: 0
+        }
+    }}/>;
+    } else {
+      return "";
+    }
+  }
+
+  resultsTable() {
+    if (this.props.qualityReport.status.state === "completed") {
+      return (
+        <table className="table table-striped">
+          <thead>
+            <tr>
+              <th>Population</th>
+              <th>Count</th>
+            </tr>
+          </thead>
+          {this.props.measure.continuousVariable ? this.continuousVariableTableBody() : this.proportionTableBody()}
+        </table>
+      );
+    } else {
+      return (<p>Loading...</p>);
+    }
+  }
+
+  proportionTableBody() {
+    return (
+      <tbody>
+        <tr>
+          <td>Numerator</td>
+          <td>{this.props.qualityReport.result.numerator}</td>
+        </tr>
+        <tr>
+          <td>Denominator</td>
+          <td>{this.props.qualityReport.result.denominator}</td>
+        </tr>
+        <tr>
+          <td>Exceptions</td>
+          <td>{this.props.qualityReport.result.exception}</td>
+        </tr>
+        <tr>
+          <td>Exclusions</td>
+          <td>{this.props.qualityReport.result.exclusion}</td>
+        </tr>
+      </tbody>
+    );
+  }
+
+  continuousVariableTableBody() {
+    return (
+      <tbody>
+        <tr>
+          <td>Measure Population</td>
+          <td>{this.props.qualityReport.result.measurePopulation}</td>
+        </tr>
+        <tr>
+          <td>Observation</td>
+          <td>{this.props.qualityReport.result.observation}</td>
+        </tr>
+      </tbody>
     );
   }
 
@@ -33,5 +135,6 @@ QualityReport.displayName = 'QualityReport';
 
 QualityReport.propTypes = {
   measure: measureProps.isRequired,
-  qualityReport: qualityReportProps.isRequired
+  qualityReport: qualityReportProps.isRequired,
+  index: PropTypes.number.isRequired
 };

--- a/src/components/SelectedMeasure.js
+++ b/src/components/SelectedMeasure.js
@@ -7,9 +7,12 @@ import qualityReportProps from '../prop-types/quality_report';
 export default class SelectedMeasure extends Component {
   render() {
     return (
-    <div>
-      <p>Measure: {this.props.selectedMeasure.name}</p>
-      {this.props.qualityReports.map((qr) => {
+    <div className="panel panel-default">
+      <div className="panel-heading">
+        <h3 className="panel-title">{this.props.selectedMeasure.name}</h3>
+      </div>
+      <div className="panel-body">
+      {this.props.qualityReports.map((qr, index) => {
         let key;
         if (qr.id) {
           key = qr.id;
@@ -19,8 +22,9 @@ export default class SelectedMeasure extends Component {
             key += qr.subId;
           }
         }
-        return <QualityReport qualityReport={qr} measure={this.props.selectedMeasure} key={key} />;
+        return <QualityReport qualityReport={qr} index={index} measure={this.props.selectedMeasure} key={key} />;
       })}
+      </div>
     </div>
     );
   }

--- a/src/containers/MeasureDisplay.js
+++ b/src/containers/MeasureDisplay.js
@@ -39,11 +39,11 @@ class MeasureDisplay extends Component {
         <div className="main">
           <div className="main-heading">
             <h1 className="title">Measures</h1>
-            {this.props.selectedMeasures.map((sm) => {
-              let qrs = this.props.qualityReports.filter(qr => qr.measureId === sm.hqmfId);
-              return <SelectedMeasure selectedMeasure={sm} qualityReports={qrs} key={sm.hqmfId} />;
-            })}
           </div>
+          {this.props.selectedMeasures.map((sm) => {
+            let qrs = this.props.qualityReports.filter(qr => qr.measureId === sm.hqmfId);
+            return <SelectedMeasure selectedMeasure={sm} qualityReports={qrs} key={sm.hqmfId} />;
+          })}
         </div>
       </div>
     );

--- a/src/prop-types/measure.js
+++ b/src/prop-types/measure.js
@@ -6,6 +6,8 @@ const measureProps = {
   description: PropTypes.string.isRequired,
   hqmfId: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  continuousVariable: PropTypes.bool,
+  episodeOfCare: PropTypes.bool,
   subMeasures: PropTypes.arrayOf(PropTypes.shape({
     shortSubtitle: PropTypes.string,
     subtitle: PropTypes.string,

--- a/src/prop-types/quality_report.js
+++ b/src/prop-types/quality_report.js
@@ -10,7 +10,9 @@ const qualityReportProps = {
     denominator: PropTypes.number,
     exception: PropTypes.number,
     exclusion: PropTypes.number,
-    initialPatientPopulation: PropTypes.number
+    initialPatientPopulation: PropTypes.number,
+    measurePopulation: PropTypes.number,
+    observation: PropTypes.number
   }),
   status: PropTypes.shape({
     state: PropTypes.string.isRequired

--- a/src/reducers/measures.js
+++ b/src/reducers/measures.js
@@ -22,7 +22,7 @@ export function flattenMeasures(measures) {
 export function flattenCategories(measures) {
   let categories = [];
   measures.forEach((m) => {
-    if (! categories.includes(m.category)) {
+    if (categories.indexOf(m.category) === -1) {
       categories.push(m.category);
     }
   });

--- a/src/reducers/measures.js
+++ b/src/reducers/measures.js
@@ -8,6 +8,8 @@ export function flattenMeasures(measures) {
     } else {
       var newMeasure = {cmsId: m.cmsId, name: m.name, category: m.category,
                         hqmfId: m.hqmfId, description: m.description,
+                        continuousVariable: m.continuousVariable,
+                        episodeOfCare: m.episodeOfCare,
                         subMeasures: []};
       newMeasure.subMeasures.push({subId: m.subId, subtitle: m.subtitle,
                                         shortSubtitle: m.shortSubtitle});

--- a/src/styles/_styles.scss
+++ b/src/styles/_styles.scss
@@ -519,25 +519,6 @@ body {
   padding: 2px 8px;
 }
 
-$table-border-color: white;
-.table {
-  thead {
-    background-color: $gray-lighter;
-    > tr > th {
-      border: none;
-      font-weight: 700;
-    }
-  }
-  > thead > tr > th, > tbody > tr > td {
-    line-height: 2;
-    font-size: 1em;
-    vertical-align: middle;
-    .btn-default {
-      padding: 7px 10px;
-    }
-  }
-}
-
 .col-patient-medical-record-id {
   max-width: 115px;
   overflow: hidden;

--- a/test/components/quality_report_test.js
+++ b/test/components/quality_report_test.js
@@ -1,0 +1,40 @@
+import { renderComponent, expect } from '../test_helper';
+import QualityReport from '../../src/components/QualityReport';
+
+describe('QualityReport', () => {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      index: 0,
+      measure: {subMeasures: [{subId: 'a', subtitle: '18-24'}, {subId: 'b', subtitle: '25-30'}],
+                category: 'Core', cmsId: "999v3", description: 'A fake measure'},
+      qualityReport: {subId: 'a', status: {state: "completed"}, measureId: '1234',
+                      result: {initialPatientPopulation: 5, numerator: 2, denominator: 3}}
+    };
+
+  });
+
+  it('will display the proper measure subtitle', () => {
+    let component = renderComponent(QualityReport, props);
+    expect(component.find(".col-md-1").first()).to.have.text('18-24');
+    props.qualityReport.subId = 'b';
+    component = renderComponent(QualityReport, props);
+    expect(component.find(".col-md-1").first()).to.have.text('25-30');
+  });
+
+  it('will display the proper measure icon', () => {
+    let component = renderComponent(QualityReport, props);
+    expect(component.find(".fa-user")).to.exist;
+    expect(component.find(".fa-stethoscope")).to.not.exist;
+    props.measure.episodeOfCare = true;
+    component = renderComponent(QualityReport, props);
+    expect(component.find(".fa-stethoscope")).to.exist;
+  });
+
+  it('will display a table of results', () => {
+    let component = renderComponent(QualityReport, props);
+    expect(component.find("tbody tr td").first()).to.have.text('Numerator');
+    expect(component.find("tbody tr td:nth-child(2)").first()).to.have.text('2');
+  });
+});

--- a/test/components/quality_report_test.js
+++ b/test/components/quality_report_test.js
@@ -8,7 +8,7 @@ describe('QualityReport', () => {
     props = {
       index: 0,
       measure: {subMeasures: [{subId: 'a', subtitle: '18-24'}, {subId: 'b', subtitle: '25-30'}],
-                category: 'Core', cmsId: "999v3", description: 'A fake measure'},
+                hqmfId: '1234', name: 'Fake', category: 'Core', cmsId: "999v3", description: 'A fake measure'},
       qualityReport: {subId: 'a', status: {state: "completed"}, measureId: '1234',
                       result: {initialPatientPopulation: 5, numerator: 2, denominator: 3}}
     };
@@ -36,5 +36,11 @@ describe('QualityReport', () => {
     let component = renderComponent(QualityReport, props);
     expect(component.find("tbody tr td").first()).to.have.text('Numerator');
     expect(component.find("tbody tr td:nth-child(2)").first()).to.have.text('2');
+  });
+
+  it('will not display an icon if it is not the first row', () => {
+    props.index = 1;
+    let component = renderComponent(QualityReport, props);
+        expect(component.find(".fa")).to.not.exist;
   });
 });


### PR DESCRIPTION
This PR cleans up the display of quality reports.
- Reports no longer wrap around the measure title
- Results now in a bootstrap panel with the measure title as the header
- Measure description now displayed
- FA icons depending on measure type (proportion, episode of care, CV)
- Table to display population counts
- Proper display of CV measure results
- Doughnut chart for result display
